### PR TITLE
fix(authorize): waiting for return of authorization from useCase before executing it

### DIFF
--- a/src/repl.js
+++ b/src/repl.js
@@ -8,7 +8,7 @@ async function list(usecases, groupBy) {
 
     let ucs = usecases.map((uc) => {
         return {
-            name: uc.tags[groupBy] + ' - ' + uc.usecase.description,
+            name: uc.tags[groupBy] + ' - ' + uc.usecase().description,
             value: uc.usecase
         }
     })
@@ -58,7 +58,8 @@ function printDoc(uc) {
             }
     }
 
-    const doc = uc.doc()
+    const usecase = uc()
+    const doc = usecase.doc()
     const style = chalk.blue.underline
     console.log(`\n${style(doc.description)} use case will execute the following steps:`)
     for (const step of doc.steps) { printStep(step) }
@@ -68,7 +69,8 @@ async function execute(usecase, user) {
 
     console.log(`\nInform the parameters for the use case execution`)
 
-    const params = usecase.requestSchema
+    const uc = usecase()
+    const params = uc.requestSchema
 
     const questions = []
     for (const param of Object.entries(params)) {
@@ -91,10 +93,10 @@ async function execute(usecase, user) {
     console.log(chalk`\n{whiteBright.bold Params:}`)
     console.log(chalk.blue(JSON.stringify(answers, null, ' ')))
 
-    const hasAccess = await usecase.authorize(user)
+    const hasAccess = await uc.authorize(user)
     if (!hasAccess) return console.log(chalk`\n{redBright.bold Access denied}`)
 
-    const result = await usecase.run(answers)
+    const result = await uc.run(answers)
     console.log(chalk`\n{whiteBright.bold Result:}`)
 
     let style = result.isOk ? chalk.green : chalk.red

--- a/src/repl.js
+++ b/src/repl.js
@@ -91,7 +91,7 @@ async function execute(usecase, user) {
     console.log(chalk`\n{whiteBright.bold Params:}`)
     console.log(chalk.blue(JSON.stringify(answers, null, ' ')))
 
-    const hasAccess = usecase.authorize(user)
+    const hasAccess = await usecase.authorize(user)
     if (!hasAccess) return console.log(chalk`\n{redBright.bold Access denied}`)
 
     const result = await usecase.run(answers)


### PR DESCRIPTION
## Proposed Changes

1. Due to the lack of 'await', the use case was being executed before being validated if the user had
permission to execute it. By default, we always leave the information that the user does not have
access, and we validate it through the 'authorize' method and as we do not wait for this validation,
we return 'not authorized'.

2. Fixing "Cannot execute use case more than once. Try instantiating a new object before executing this use case." When the same useCase was executed using the REPL

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
